### PR TITLE
Allow Parquet map key to be optional

### DIFF
--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -548,10 +548,23 @@ Status MapToSchemaField(const GroupNode& group, LevelInfo current_levels,
     return Status::Invalid("Key-value map node must have 1 or 2 child elements. Found: ",
                            key_value.field_count());
   }
+
+  /*
+   * If Parquet file was written by Flink, key type of map column is allowed to be optional, like this:
+   * optional group event_info (MAP) {
+   *   repeated group key_value {
+   *     optional binary key (UTF8);
+   *     optional binary value (UTF8);
+   *   }
+   * }
+   *
+   * Refer to: https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/types/#constructured-data-types
   const Node& key_node = *key_value.field(0);
   if (!key_node.is_required()) {
     return Status::Invalid("Map keys must be annotated as required.");
   }
+  */
+
   // Arrow doesn't support 1 column maps (i.e. Sets).  The options are to either
   // make the values column nullable, or process the map as a list.  We choose the latter
   // as it is simpler.


### PR DESCRIPTION
## What's the problem?
When HDFS Parquet files are written by flink, and there is a map type column in the schema, then its key type is optional. It will cause CH to throw exception when reading such parquet files because arrow lib forbidden optional key in map.  

Like this: 
```
$ hadoop jar parquet-tools-1.9.0.jar  schema hdfs://path/to/flink/written/parquet/file

  optional group log_extra (MAP) {
    repeated group key_value {
      optional binary key (UTF8);
      optional binary value (UTF8);
    }
  }
  optional group event_info (MAP) {
    repeated group key_value {
      optional binary key (UTF8);
      optional binary value (UTF8);
    }
  }
```

Refer to the map definition of flink: https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/types/#constructured-data-types


## How to solve it 
Remove the restriction in arrow lib.
