### PR TITLE
remove debug table validation checks

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -619,7 +619,6 @@ TableBatchReader::TableBatchReader(const Table& table)
   for (int i = 0; i < table.num_columns(); ++i) {
     column_data_[i] = table.column(i).get();
   }
-  DCHECK(table_.Validate().ok());
 }
 
 TableBatchReader::TableBatchReader(std::shared_ptr<Table> table)
@@ -633,7 +632,6 @@ TableBatchReader::TableBatchReader(std::shared_ptr<Table> table)
   for (int i = 0; i < owned_table_->num_columns(); ++i) {
     column_data_[i] = owned_table_->column(i).get();
   }
-  DCHECK(table_.Validate().ok());
 }
 
 std::shared_ptr<Schema> TableBatchReader::schema() const { return table_.schema(); }


### PR DESCRIPTION
Follow up for previous PR: https://github.com/ClickHouse/arrow/pull/69.

Remove debug validation checks on table. The validation checks mainly fail for debug builds and what they do is to actually validate the metadata for a table. While dealing with indices for dictionaries, it looks like for compatibility, we accept signed or unsigned 32 or 64 bit integers. However, arrow dictionary builder AppendIndices only accepts signed integers. So, we end up appending signed integers while dictionary schema could still be unsigned integers. So, when the validation happens, it checks if the dictionary schema and the actual column data are the same types. Since it's possible to have uint64 schema with int64 columns, this leads to errors like (and similar error for uint32):
```
Column data for field 0 with type dictionary<values=string, indices=int64,
ordered=0> is inconsistent with schema dictionary<values=string,
indices=uint64, ordered=0>
```
Unfortunately, I couldn't find a sane way to preserve this behavior since the current behavior exists for compatibility with pandas format it looks like. The settings to support both singed and unsigned dictionary indices was added in: https://github.com/ClickHouse/ClickHouse/pull/58519.

This is where the current assert fails:
https://github.com/ClickHouse/arrow/blob/214fd3c1803621de00e627bf8726e9b0b38eda2a/cpp/src/arrow/table.cc#L181 

which is ultimately checked here:
https://github.com/ClickHouse/arrow/blob/214fd3c1803621de00e627bf8726e9b0b38eda2a/cpp/src/arrow/table.cc#L220