### PR TITLE
GH-45099: [C++] Avoid static const variable in the status.h

### DIFF
--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -138,6 +138,16 @@ std::string Status::ToStringWithoutContextLines() const {
   return message;
 }
 
+const std::string& Status::message() const {
+  static const std::string no_message = "";
+  return ok() ? no_message : state_->msg;
+}
+
+const std::shared_ptr<StatusDetail>& Status::detail() const {
+  static std::shared_ptr<StatusDetail> no_detail = NULLPTR;
+  return state_ ? state_->detail : no_detail;
+}
+
 void Status::Abort() const { Abort(std::string()); }
 
 void Status::Abort(const std::string& message) const {

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -329,16 +329,10 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   constexpr StatusCode code() const { return ok() ? StatusCode::OK : state_->code; }
 
   /// \brief Return the specific error message attached to this status.
-  const std::string& message() const {
-    static const std::string no_message = "";
-    return ok() ? no_message : state_->msg;
-  }
+  const std::string& message() const;
 
   /// \brief Return the status detail attached to this message.
-  const std::shared_ptr<StatusDetail>& detail() const {
-    static std::shared_ptr<StatusDetail> no_detail = NULLPTR;
-    return state_ ? state_->detail : no_detail;
-  }
+  const std::shared_ptr<StatusDetail>& detail() const;
 
   /// \brief Return a new Status copying the existing status, but
   /// updating with the existing detail.


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apache/arrow/pull/45100 to our branch.